### PR TITLE
fix for dns file permissions in DSM

### DIFF
--- a/diskstation_dns_modify.sh
+++ b/diskstation_dns_modify.sh
@@ -47,10 +47,11 @@ DHCPAssigned=/etc/dhcpd/dhcpd.conf
 getdsmversion(){
   #todo: filter out variables that are not used. https://community.synology.com/enu/forum/17/post/72754
   source /etc.defaults/VERSION
+  echo $majorversion
 }
-getdsmversion
+dsmversion=$(getdsmversion)
 
-case  $majorversion  in
+case  $dsmversion  in
   6)       
     owner=nobody
     ;;

--- a/diskstation_dns_modify.sh
+++ b/diskstation_dns_modify.sh
@@ -45,9 +45,11 @@ ZonePath=$ZoneRootDir/named/etc/zone/master
 DHCPAssigned=/etc/dhcpd/dhcpd.conf
 
 getdsmversion(){
-  #todo: filter out variables that are not used. https://community.synology.com/enu/forum/17/post/72754
-  source /etc.defaults/VERSION
+  tmpfile=/tmp/$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32)
+  echo $(head -n 1 /etc.defaults/VERSION) > $tmpfile
+  source $tmpfile
   echo $majorversion
+  rm -f $tmpfile
 }
 dsmversion=$(getdsmversion)
 

--- a/diskstation_dns_modify.sh
+++ b/diskstation_dns_modify.sh
@@ -44,6 +44,21 @@ ZoneRootDir=/var/packages/DNSServer/target
 ZonePath=$ZoneRootDir/named/etc/zone/master
 DHCPAssigned=/etc/dhcpd/dhcpd.conf
 
+getdsmversion(){
+  #todo: filter out variables that are not used. https://community.synology.com/enu/forum/17/post/72754
+  source /etc.defaults/VERSION
+}
+getdsmversion
+
+case  $majorversion  in
+  6)       
+    owner=nobody
+    ;;
+  7)
+    owner=DNSServer
+    ;;
+esac
+
 NetworkInterfaces=",`ip -o link show | awk -F': ' '{printf $2","}'`"
 
 date_echo "Network interfaces:"
@@ -197,7 +212,7 @@ incrementSerial $BackupPath/$ReverseMasterFile.new > $BackupPath/$ReverseMasterF
 # Ensure the owner/group and modes are set at default
 # then overwrite the original files
 date_echo "Overwriting with updated files: $ForwardMasterFile $ReverseMasterFile"
-if ! chown nobody:nobody $BackupPath/$ForwardMasterFile.bumped $BackupPath/$ReverseMasterFile.bumped ; then
+if ! chown $owner:$owner $BackupPath/$ForwardMasterFile.bumped $BackupPath/$ReverseMasterFile.bumped ; then
   date_echo "Error:  Cannot change file ownership"
   date_echo ""
   date_echo "Try running this script as root for correct permissions"


### PR DESCRIPTION
In DSM 7, the zone files are owned by DNSServer:DNSServer. Once a sync runs, you can no longer add zone records - https://github.com/gclayburg/synology-diskstation-scripts/issues/38